### PR TITLE
vproxy: add icap tcp connect timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "http",
  "itoa",
  "kanal",
+ "log",
  "memchr",
  "rustls-pki-types",
  "thiserror",

--- a/lib/vey-icap-client/Cargo.toml
+++ b/lib/vey-icap-client/Cargo.toml
@@ -31,6 +31,7 @@ vey-http.workspace = true
 vey-h2.workspace = true
 vey-smtp-proto.workspace = true
 vey-yaml = { workspace = true, optional = true, features = ["rustls", "http"] }
+log.workspace = true
 
 [features]
 default = []

--- a/lib/vey-icap-client/src/service/config/mod.rs
+++ b/lib/vey-icap-client/src/service/config/mod.rs
@@ -34,6 +34,7 @@ pub struct IcapServiceConfig {
     pub(crate) tls_name: ServerName<'static>,
     pub(crate) connection_pool: ConnectionPoolConfig,
     pub(crate) tcp_keepalive: TcpKeepAliveConfig,
+    pub(crate) tcp_connect_timeout: Duration,
     #[cfg(unix)]
     pub(crate) use_unix_socket: Option<PathBuf>,
     pub(crate) icap_206_enable: bool,
@@ -75,6 +76,7 @@ impl IcapServiceConfig {
             tls_name,
             connection_pool: ConnectionPoolConfig::default(),
             tcp_keepalive: TcpKeepAliveConfig::default_enabled(),
+            tcp_connect_timeout: Duration::from_secs(1),
             #[cfg(unix)]
             use_unix_socket: None,
             icap_206_enable: false,
@@ -88,6 +90,10 @@ impl IcapServiceConfig {
 
     pub fn set_tcp_keepalive(&mut self, config: TcpKeepAliveConfig) {
         self.tcp_keepalive = config;
+    }
+
+    pub fn set_tcp_connect_timeout(&mut self, time: Duration) {
+        self.tcp_connect_timeout = time;
     }
 
     pub fn set_tls_client(&mut self, config: RustlsClientConfigBuilder) {

--- a/lib/vey-icap-client/src/service/config/yaml.rs
+++ b/lib/vey-icap-client/src/service/config/yaml.rs
@@ -46,6 +46,12 @@ impl IcapServiceConfig {
                 config.set_tcp_keepalive(keepalive);
                 Ok(())
             }
+            "tcp_connect_timeout" => {
+                let connect_timeout = vey_yaml::humanize::as_duration(v)
+                    .context(format!("invalid humanize duration value for key {k}"))?;
+                config.set_tcp_connect_timeout(connect_timeout);
+                Ok(())
+            }
             #[cfg(unix)]
             "use_unix_socket" => {
                 let path = vey_yaml::value::as_absolute_path(v)

--- a/lib/vey-icap-client/src/service/connection.rs
+++ b/lib/vey-icap-client/src/service/connection.rs
@@ -117,7 +117,17 @@ impl IcapConnector {
             &Default::default(),
             true,
         )?;
-        let stream = socket.connect(peer).await?;
+
+        let stream =
+            match tokio::time::timeout(self.config.tcp_connect_timeout, socket.connect(peer)).await
+            {
+                Ok(Ok(s)) => Ok(s),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "tcp connection with ICAP server timed out",
+                )),
+            }?;
 
         if let Some(client) = &self.tls_client {
             let tls_connector = TlsConnector::from(client.driver.clone());

--- a/lib/vey-icap-client/src/service/pool.rs
+++ b/lib/vey-icap-client/src/service/pool.rs
@@ -48,7 +48,9 @@ impl IcapServicePool {
         connector: Arc<IcapConnector>,
     ) -> Self {
         let options = Arc::new(IcapServiceOptions::new_expired(config.method));
-        let check_interval = tokio::time::interval(config.connection_pool.check_interval());
+        let mut check_interval = tokio::time::interval(config.connection_pool.check_interval());
+        check_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
         let (pool_cmd_sender, pool_cmd_receiver) = mpsc::channel(POOL_CMD_CHANNEL_SIZE);
         let (conn_req_sender, conn_req_receiver) =
             kanal::bounded_async(config.connection_pool.max_idle_count());

--- a/sphinx/vey-values/configuration/values/audit.rst
+++ b/sphinx/vey-values/configuration/values/audit.rst
@@ -86,6 +86,14 @@ If the value is a map, the following keys are supported:
 
   **default**: enabled with default value
 
+* tcp_connect_timeout
+
+  **optional**, **type**: :ref:`humanize duration <conf_value_humanize_duration>`
+
+  TCP connection timeout configuration for establishing connection to the ICAP server.
+
+  **default**: 1s
+
 * icap_connection_pool
 
   **optional**, **type**: :ref:`connection pool <conf_value_connection_pool_config>`


### PR DESCRIPTION
### Problem / Solution

Adds a configurable `tcp_connect_timeout` to the ICAP module's connection
establishment path. Previously `socket.connect()` was awaited with no bound,
leaving dials to the OS default. 

### Change

- `IcapServiceConfig` gains `tcp_connect_timeout` (default: 1s)
- `connect()` wraps the dial in `tokio::time::timeout`

Closes #66 