### PR TITLE
vey-keyless: add qatlib crypto backend without OpenSSL async jobs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install capnproto libjemalloc-dev libmimalloc-dev libc-ares-dev libssl-dev libpython3-dev liblua5.4-dev
-          sudo apt-get install libbpf-dev libcrypto-mb-dev
+          sudo apt-get install libbpf-dev libcrypto-mb-dev libqat-dev libusdm-dev pkg-config
       - name: Install binutils
         run: |
           cargo install cargo-binutils@0.3.6
@@ -55,6 +55,7 @@ jobs:
       - name: run unit test
         run: |
           ./scripts/coverage/lib_unit_test.sh
+
       - name: Upload coverage data
         uses: codecov/codecov-action@v7
         with:
@@ -151,7 +152,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install capnproto libmimalloc-dev libssl-dev libcrypto-mb-dev pkg-config
+          sudo apt-get install capnproto libmimalloc-dev libssl-dev libcrypto-mb-dev libqat-dev libusdm-dev pkg-config
       - name: Install binutils
         run: |
           cargo install cargo-binutils@0.3.6
@@ -160,6 +161,7 @@ jobs:
       - name: run unit test
         run: |
           ./scripts/coverage/vey-keyless.sh
+
       - name: Upload coverage data
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/linux-basic.yml
+++ b/.github/workflows/linux-basic.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Cargo build
         run: cargo build --features jemalloc,ebpf,lua54
       - name: Cargo test
-        run: cargo test --workspace --features jemalloc,lua54 --exclude vey-crypto-mb
+        run: cargo test --workspace --features jemalloc,lua54 --exclude vey-crypto-mb --exclude vey-qat
   clippy:
     name: Clippy
     runs-on: ubuntu-26.04
@@ -80,4 +80,4 @@ jobs:
       - name: Cargo clean
         run: cargo clean
       - name: Cargo clippy
-        run: cargo clippy --tests --workspace --features jemalloc,ebpf,lua54 --exclude vey-crypto-mb -- --deny warnings
+        run: cargo clippy --tests --workspace --features jemalloc,ebpf,lua54 --exclude vey-crypto-mb --exclude vey-qat -- --deny warnings

--- a/.github/workflows/linux-extra.yml
+++ b/.github/workflows/linux-extra.yml
@@ -153,3 +153,32 @@ jobs:
           cargo test -p vey-crypto-mb
       - name: Cargo test vey-keyless
         run: cargo test -p vey-keyless --features crypto-mb
+  qat:
+    name: Build with qatlib (linux x86_64)
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install capnproto libssl-dev libqat-dev libusdm-dev pkg-config
+      - name: Cargo clean
+        run: cargo clean
+      - name: Cargo build
+        run: cargo build -p vey-qat -p vey-keyless --features qat
+      - name: Cargo clippy
+        run: |
+          cargo clippy -p vey-qat -- --deny warnings
+          cargo clippy -p vey-keyless --features qat -- --deny warnings
+      - name: Cargo test
+        run: |
+          cargo test -p vey-qat
+          cargo test -p vey-keyless --features qat

--- a/.github/workflows/macos-basic.yml
+++ b/.github/workflows/macos-basic.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Cargo clippy
         run: cargo clippy --tests --features jemalloc,lua55 -- --deny warnings
       - name: Cargo test
-        run: cargo test --workspace --features jemalloc,lua55 --exclude vey-journal --exclude vey-reuseport --exclude vey-crypto-mb
+        run: cargo test --workspace --features jemalloc,lua55 --exclude vey-journal --exclude vey-reuseport --exclude vey-crypto-mb --exclude vey-qat

--- a/.github/workflows/windows-basic.yml
+++ b/.github/workflows/windows-basic.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Cargo clippy
         run: cargo clippy --no-default-features --features $env:WIN_FEATURES --tests -- --deny warnings
       - name: Cargo test
-        run: cargo test --no-default-features --features $env:WIN_FEATURES --workspace --exclude vey-journal --exclude vey-reuseport --exclude vey-crypto-mb
+        run: cargo test --no-default-features --features $env:WIN_FEATURES --workspace --exclude vey-journal --exclude vey-reuseport --exclude vey-crypto-mb --exclude vey-qat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,6 +3375,7 @@ dependencies = [
  "vey-macros",
  "vey-mimalloc",
  "vey-openssl",
+ "vey-qat",
  "vey-rustls-provider",
  "vey-slog-types",
  "vey-socket",
@@ -3634,6 +3635,18 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "capnpc",
+]
+
+[[package]]
+name = "vey-qat"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "log",
+ "pkg-config",
+ "tokio",
+ "variant-ssl",
+ "variant-ssl-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "lib/vey-codec",
     "lib/vey-compat",
     "lib/vey-crypto-mb",
+    "lib/vey-qat",
     "lib/vey-ctl",
     "lib/vey-daemon",
     "lib/vey-datetime",
@@ -215,6 +216,7 @@ vey-clap = { version = "0.2", path = "lib/vey-clap" }
 vey-codec = { version = "0.1", path = "lib/vey-codec" }
 vey-compat = { version = "0.2", path = "lib/vey-compat" }
 vey-crypto-mb = { version = "0.1", path = "lib/vey-crypto-mb" }
+vey-qat = { version = "0.1", path = "lib/vey-qat" }
 vey-ctl = { version = "0.2", path = "lib/vey-ctl" }
 vey-daemon = { version = "0.4", path = "lib/vey-daemon" }
 vey-datetime = { version = "0.2", path = "lib/vey-datetime" }

--- a/lib/vey-qat/Cargo.toml
+++ b/lib/vey-qat/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vey-qat"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Intel qatlib helpers for asynchronous asymmetric crypto"
+
+[dependencies]
+libc.workspace = true
+log.workspace = true
+openssl.workspace = true
+openssl-sys.workspace = true
+tokio = { workspace = true, features = ["net", "rt", "sync", "time"] }
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/lib/vey-qat/build.rs
+++ b/lib/vey-qat/build.rs
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+fn main() {
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if os != "linux" || arch != "x86_64" {
+        // Unsupported host/target: skip native linking so workspace builds on
+        // macOS/Windows/etc. do not require qatlib.
+        return;
+    }
+
+    // `qatlib.pc` Requires: libqat libusdm
+    let lib = pkg_config::Config::new()
+        .probe("qatlib")
+        .expect("qatlib not found via pkg-config (install libqat-dev / libusdm-dev)");
+    for path in &lib.include_paths {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}

--- a/lib/vey-qat/src/ecdsa.rs
+++ b/lib/vey-qat/src/ecdsa.rs
@@ -1,0 +1,218 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use std::sync::Arc;
+
+use openssl::bn::{BigNum, BigNumContext};
+use openssl::ecdsa::EcdsaSig;
+use openssl::foreign_types::ForeignType;
+use openssl::nid::Nid;
+use openssl::pkey::{PKeyRef, Private};
+use tokio::sync::oneshot;
+
+use crate::Error;
+use crate::ffi::{
+    self, CPA_CY_EC_FIELD_TYPE_PRIME, CPA_STATUS_SUCCESS, CPA_TRUE, CpaBoolean,
+    CpaCyEcdsaSignRSOpData, CpaFlatBuffer, CpaStatus,
+};
+use crate::mem::DmaBuf;
+use crate::openssl_ffi;
+use crate::runtime::QatRuntime;
+
+type EcdsaRs = (Vec<u8>, Vec<u8>);
+
+struct EcdsaPending {
+    tx: Option<oneshot::Sender<Result<EcdsaRs, Error>>>,
+    xg: DmaBuf,
+    yg: DmaBuf,
+    n: DmaBuf,
+    q: DmaBuf,
+    a: DmaBuf,
+    b: DmaBuf,
+    k: DmaBuf,
+    m: DmaBuf,
+    d: DmaBuf,
+    r: DmaBuf,
+    s: DmaBuf,
+    op_data: Box<CpaCyEcdsaSignRSOpData>,
+    r_flat: Box<CpaFlatBuffer>,
+    s_flat: Box<CpaFlatBuffer>,
+    sign_status: Box<CpaBoolean>,
+}
+
+unsafe extern "C" fn ecdsa_cb(
+    tag: *mut libc::c_void,
+    status: CpaStatus,
+    _op: *mut libc::c_void,
+    multiply_status: CpaBoolean,
+    _r: *mut CpaFlatBuffer,
+    _s: *mut CpaFlatBuffer,
+) {
+    let pending = unsafe { Box::from_raw(tag as *mut EcdsaPending) };
+    let result = if status == CPA_STATUS_SUCCESS && multiply_status == CPA_TRUE {
+        Ok((pending.r.as_slice().to_vec(), pending.s.as_slice().to_vec()))
+    } else {
+        Err(Error::Cpa(status))
+    };
+    if let Some(tx) = pending.tx {
+        let _ = tx.send(result);
+    }
+}
+
+fn bn_to_dma(bn: &openssl::bn::BigNumRef, len: usize) -> Option<DmaBuf> {
+    let mut buf = DmaBuf::alloc(len)?;
+    if !buf.copy_from_be_padded(&bn.to_vec()) {
+        return None;
+    }
+    Some(buf)
+}
+
+fn field_len_for_nid(nid: Nid) -> Option<usize> {
+    match nid {
+        Nid::X9_62_PRIME256V1 => Some(32),
+        Nid::SECP384R1 => Some(48),
+        Nid::SECP521R1 => Some(66),
+        _ => None,
+    }
+}
+
+/// ECDSA sign; returns DER-encoded signature.
+pub async fn ecdsa_sign_der(
+    runtime: Arc<QatRuntime>,
+    key: &PKeyRef<Private>,
+    digest: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let ec = key.ec_key().map_err(|_| Error::Prepare)?;
+    let group = ec.group();
+    let nid = group.curve_name().ok_or(Error::Prepare)?;
+    let flen = field_len_for_nid(nid).ok_or(Error::Prepare)?;
+
+    let mut ctx = BigNumContext::new().map_err(|_| Error::Prepare)?;
+    let mut p = BigNum::new().map_err(|_| Error::Prepare)?;
+    let mut a = BigNum::new().map_err(|_| Error::Prepare)?;
+    let mut b = BigNum::new().map_err(|_| Error::Prepare)?;
+    group
+        .components_gfp(&mut p, &mut a, &mut b, &mut ctx)
+        .map_err(|_| Error::Prepare)?;
+    let mut order = BigNum::new().map_err(|_| Error::Prepare)?;
+    group
+        .order(&mut order, &mut ctx)
+        .map_err(|_| Error::Prepare)?;
+    let mut gx = BigNum::new().map_err(|_| Error::Prepare)?;
+    let mut gy = BigNum::new().map_err(|_| Error::Prepare)?;
+    let generator = group.generator_opt().ok_or(Error::Prepare)?;
+    generator
+        .affine_coordinates_gfp(group, &mut gx, &mut gy, &mut ctx)
+        .map_err(|_| Error::Prepare)?;
+
+    let k = {
+        let eph = BigNum::new().map_err(|_| Error::Prepare)?;
+        let mut ok = false;
+        for _ in 0..64 {
+            let rc = unsafe { openssl_ffi::BN_priv_rand_range(eph.as_ptr(), order.as_ptr()) };
+            let is_zero = unsafe { openssl_ffi::BN_is_zero(eph.as_ptr()) == 1 };
+            if rc == 1 && !is_zero {
+                ok = true;
+                break;
+            }
+        }
+        if !ok {
+            return Err(Error::Prepare);
+        }
+        eph
+    };
+
+    let mut msg = vec![0u8; flen];
+    if digest.len() >= flen {
+        msg.copy_from_slice(&digest[..flen]);
+    } else {
+        msg[flen - digest.len()..].copy_from_slice(digest);
+    }
+
+    let mut xg = bn_to_dma(&gx, flen).ok_or(Error::Prepare)?;
+    let mut yg = bn_to_dma(&gy, flen).ok_or(Error::Prepare)?;
+    let mut n = bn_to_dma(&order, flen).ok_or(Error::Prepare)?;
+    let mut q = bn_to_dma(&p, flen).ok_or(Error::Prepare)?;
+    let mut aa = bn_to_dma(&a, flen).ok_or(Error::Prepare)?;
+    let mut bb = bn_to_dma(&b, flen).ok_or(Error::Prepare)?;
+    let mut kk = bn_to_dma(&k, flen).ok_or(Error::Prepare)?;
+    let mut mm = DmaBuf::alloc(flen).ok_or(Error::Prepare)?;
+    mm.as_mut_slice().copy_from_slice(&msg);
+    let mut dd = bn_to_dma(ec.private_key(), flen).ok_or(Error::Prepare)?;
+    let mut r_buf = DmaBuf::alloc(flen).ok_or(Error::Prepare)?;
+    let mut s_buf = DmaBuf::alloc(flen).ok_or(Error::Prepare)?;
+
+    let op_data = Box::new(CpaCyEcdsaSignRSOpData {
+        xg: xg.flat(),
+        yg: yg.flat(),
+        n: n.flat(),
+        q: q.flat(),
+        a: aa.flat(),
+        b: bb.flat(),
+        k: kk.flat(),
+        m: mm.flat(),
+        d: dd.flat(),
+        fieldType: CPA_CY_EC_FIELD_TYPE_PRIME,
+    });
+    let r_flat = Box::new(r_buf.flat());
+    let s_flat = Box::new(s_buf.flat());
+
+    let mut pending = Box::new(EcdsaPending {
+        tx: None,
+        xg,
+        yg,
+        n,
+        q,
+        a: aa,
+        b: bb,
+        k: kk,
+        m: mm,
+        d: dd,
+        r: r_buf,
+        s: s_buf,
+        op_data,
+        r_flat,
+        s_flat,
+        sign_status: Box::new(CPA_TRUE),
+    });
+
+    pending.op_data.xg = pending.xg.flat();
+    pending.op_data.yg = pending.yg.flat();
+    pending.op_data.n = pending.n.flat();
+    pending.op_data.q = pending.q.flat();
+    pending.op_data.a = pending.a.flat();
+    pending.op_data.b = pending.b.flat();
+    pending.op_data.k = pending.k.flat();
+    pending.op_data.m = pending.m.flat();
+    pending.op_data.d = pending.d.flat();
+    pending.r_flat = Box::new(pending.r.flat());
+    pending.s_flat = Box::new(pending.s.flat());
+
+    let (tx, rx) = oneshot::channel();
+    pending.tx = Some(tx);
+    let tag = Box::into_raw(pending);
+
+    let sts = unsafe {
+        ffi::cpaCyEcdsaSignRS(
+            runtime.instance(),
+            Some(ecdsa_cb),
+            tag as *mut _,
+            (*tag).op_data.as_ref(),
+            (*tag).sign_status.as_mut(),
+            (*tag).r_flat.as_mut(),
+            (*tag).s_flat.as_mut(),
+        )
+    };
+    if sts != CPA_STATUS_SUCCESS {
+        let _ = unsafe { Box::from_raw(tag) };
+        return Err(Error::Cpa(sts));
+    }
+
+    let (r, s) = rx.await.map_err(|_| Error::Canceled)??;
+    let r_bn = BigNum::from_slice(&r).map_err(|_| Error::Prepare)?;
+    let s_bn = BigNum::from_slice(&s).map_err(|_| Error::Prepare)?;
+    let sig = EcdsaSig::from_private_components(r_bn, s_bn).map_err(|_| Error::Prepare)?;
+    sig.to_der().map_err(|_| Error::Prepare)
+}

--- a/lib/vey-qat/src/ffi.rs
+++ b/lib/vey-qat/src/ffi.rs
@@ -1,0 +1,164 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
+
+use libc::{c_char, c_int, c_void};
+
+pub type Cpa8U = u8;
+pub type Cpa16U = u16;
+pub type Cpa32U = u32;
+pub type Cpa32S = i32;
+pub type Cpa64U = u64;
+pub type CpaStatus = Cpa32S;
+pub type CpaBoolean = c_int;
+pub type CpaInstanceHandle = *mut c_void;
+pub type CpaPhysicalAddr = Cpa64U;
+pub type CpaVirtualToPhysical = Option<unsafe extern "C" fn(*mut c_void) -> CpaPhysicalAddr>;
+
+pub const CPA_STATUS_SUCCESS: CpaStatus = 0;
+pub const CPA_STATUS_FAIL: CpaStatus = -1;
+pub const CPA_STATUS_RETRY: CpaStatus = -2;
+pub const CPA_TRUE: CpaBoolean = 1;
+pub const CPA_FALSE: CpaBoolean = 0;
+
+pub const CPA_CY_RSA_VERSION_TWO_PRIME: c_int = 1;
+pub const CPA_CY_RSA_PRIVATE_KEY_REP_TYPE_2: c_int = 2;
+pub const CPA_CY_EC_FIELD_TYPE_PRIME: c_int = 1;
+
+/// `CpaAccelerationServiceType::CPA_ACC_SVC_TYPE_CRYPTO`
+pub const CPA_ACC_SVC_TYPE_CRYPTO: c_int = 0;
+/// `CpaInstanceResponseMode::CPA_INST_RX_NOTIFY_BY_EVENT`
+pub const CPA_INST_RX_NOTIFY_BY_EVENT: c_int = 2;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CpaFlatBuffer {
+    pub dataLenInBytes: Cpa32U,
+    pub pData: *mut Cpa8U,
+}
+
+#[repr(C)]
+pub struct CpaCyRsaPublicKey {
+    pub modulusN: CpaFlatBuffer,
+    pub publicExponentE: CpaFlatBuffer,
+}
+
+#[repr(C)]
+pub struct CpaCyRsaPrivateKeyRep1 {
+    pub modulusN: CpaFlatBuffer,
+    pub privateExponentD: CpaFlatBuffer,
+}
+
+#[repr(C)]
+pub struct CpaCyRsaPrivateKeyRep2 {
+    pub prime1P: CpaFlatBuffer,
+    pub prime2Q: CpaFlatBuffer,
+    pub exponent1Dp: CpaFlatBuffer,
+    pub exponent2Dq: CpaFlatBuffer,
+    pub coefficientQInv: CpaFlatBuffer,
+}
+
+#[repr(C)]
+pub struct CpaCyRsaPrivateKey {
+    pub version: c_int,
+    pub privateKeyRepType: c_int,
+    pub privateKeyRep1: CpaCyRsaPrivateKeyRep1,
+    pub privateKeyRep2: CpaCyRsaPrivateKeyRep2,
+}
+
+#[repr(C)]
+pub struct CpaCyRsaDecryptOpData {
+    pub pRecipientPrivateKey: *mut CpaCyRsaPrivateKey,
+    pub inputData: CpaFlatBuffer,
+}
+
+#[repr(C)]
+pub struct CpaCyEcdsaSignRSOpData {
+    pub xg: CpaFlatBuffer,
+    pub yg: CpaFlatBuffer,
+    pub n: CpaFlatBuffer,
+    pub q: CpaFlatBuffer,
+    pub a: CpaFlatBuffer,
+    pub b: CpaFlatBuffer,
+    pub k: CpaFlatBuffer,
+    pub m: CpaFlatBuffer,
+    pub d: CpaFlatBuffer,
+    pub fieldType: c_int,
+}
+
+pub type CpaCyGenFlatBufCbFunc = Option<
+    unsafe extern "C" fn(
+        pCallbackTag: *mut c_void,
+        status: CpaStatus,
+        pOpdata: *mut c_void,
+        pOut: *mut CpaFlatBuffer,
+    ),
+>;
+
+pub type CpaCyEcdsaSignRSCbFunc = Option<
+    unsafe extern "C" fn(
+        pCallbackTag: *mut c_void,
+        status: CpaStatus,
+        pOpData: *mut c_void,
+        multiplyStatus: CpaBoolean,
+        pR: *mut CpaFlatBuffer,
+        pS: *mut CpaFlatBuffer,
+    ),
+>;
+
+unsafe extern "C" {
+    pub fn icp_sal_userStart(pProcessName: *const c_char) -> CpaStatus;
+    pub fn icp_sal_userStop() -> CpaStatus;
+    pub fn icp_sal_CyPollInstance(
+        instanceHandle: CpaInstanceHandle,
+        response_quota: Cpa32U,
+    ) -> CpaStatus;
+    pub fn icp_sal_CyGetFileDescriptor(
+        instanceHandle: CpaInstanceHandle,
+        fd: *mut c_int,
+    ) -> CpaStatus;
+    pub fn icp_sal_CyPutFileDescriptor(instanceHandle: CpaInstanceHandle) -> CpaStatus;
+
+    pub fn cpaInstanceSetResponseMode(
+        instanceHandle: CpaInstanceHandle,
+        accelerationServiceType: c_int,
+        responseMode: c_int,
+    ) -> CpaStatus;
+
+    pub fn cpaCyGetNumInstances(pNumInstances: *mut Cpa16U) -> CpaStatus;
+    pub fn cpaCyGetInstances(
+        numInstances: Cpa16U,
+        cyInstances: *mut CpaInstanceHandle,
+    ) -> CpaStatus;
+    pub fn cpaCyStartInstance(instanceHandle: CpaInstanceHandle) -> CpaStatus;
+    pub fn cpaCyStopInstance(instanceHandle: CpaInstanceHandle) -> CpaStatus;
+    pub fn cpaCySetAddressTranslation(
+        instanceHandle: CpaInstanceHandle,
+        virtual2Physical: CpaVirtualToPhysical,
+    ) -> CpaStatus;
+
+    pub fn cpaCyRsaDecrypt(
+        instanceHandle: CpaInstanceHandle,
+        pRsaDecryptCb: CpaCyGenFlatBufCbFunc,
+        pCallbackTag: *mut c_void,
+        pDecryptOpData: *const CpaCyRsaDecryptOpData,
+        pOutputData: *mut CpaFlatBuffer,
+    ) -> CpaStatus;
+
+    pub fn cpaCyEcdsaSignRS(
+        instanceHandle: CpaInstanceHandle,
+        pCb: CpaCyEcdsaSignRSCbFunc,
+        pCallbackTag: *mut c_void,
+        pOpData: *const CpaCyEcdsaSignRSOpData,
+        pSignStatus: *mut CpaBoolean,
+        pR: *mut CpaFlatBuffer,
+        pS: *mut CpaFlatBuffer,
+    ) -> CpaStatus;
+
+    pub fn qaeMemAllocNUMA(size: usize, node: c_int, phys_alignment_byte: usize) -> *mut c_void;
+    pub fn qaeMemFreeNUMA(ptr: *mut *mut c_void);
+    pub fn qaeVirtToPhysNUMA(pVirtAddr: *mut c_void) -> u64;
+}

--- a/lib/vey-qat/src/lib.rs
+++ b/lib/vey-qat/src/lib.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+//! High-level helpers around Intel `qatlib` asynchronous asymmetric crypto.
+//!
+//! Supported only on Linux `x86_64` (requires system `qatlib` via pkg-config).
+
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+mod ecdsa;
+mod ffi;
+mod mem;
+mod openssl_ffi;
+mod padding;
+mod rsa;
+mod runtime;
+
+pub use ecdsa::ecdsa_sign_der;
+pub use rsa::{rsa_decrypt, rsa_sign_pkcs1, rsa_sign_pss};
+pub use runtime::QatRuntime;
+
+use crate::ffi::CpaStatus;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    Prepare,
+    Cpa(CpaStatus),
+    Canceled,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Prepare => write!(f, "qat prepare failed"),
+            Error::Cpa(s) => write!(f, "qat cpa status {s}"),
+            Error::Canceled => write!(f, "qat operation canceled"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/lib/vey-qat/src/mem.rs
+++ b/lib/vey-qat/src/mem.rs
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use std::ptr;
+
+use crate::ffi::{self, CpaFlatBuffer};
+
+/// Contiguous DMA buffer allocated via USDM (`qaeMemAllocNUMA`).
+pub struct DmaBuf {
+    ptr: *mut u8,
+    len: usize,
+}
+
+unsafe impl Send for DmaBuf {}
+unsafe impl Sync for DmaBuf {}
+
+impl DmaBuf {
+    pub fn alloc(len: usize) -> Option<Self> {
+        if len == 0 {
+            return None;
+        }
+        let ptr = unsafe { ffi::qaeMemAllocNUMA(len, 0, 64) as *mut u8 };
+        if ptr.is_null() {
+            return None;
+        }
+        unsafe {
+            ptr::write_bytes(ptr, 0, len);
+        }
+        Some(DmaBuf { ptr, len })
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+
+    pub fn copy_from_be_padded(&mut self, src: &[u8]) -> bool {
+        if src.len() > self.len {
+            return false;
+        }
+        let len = self.len;
+        let dst = self.as_mut_slice();
+        dst.fill(0);
+        dst[len - src.len()..].copy_from_slice(src);
+        true
+    }
+
+    pub fn flat(&mut self) -> CpaFlatBuffer {
+        CpaFlatBuffer {
+            dataLenInBytes: self.len as u32,
+            pData: self.ptr,
+        }
+    }
+}
+
+impl Drop for DmaBuf {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            let mut p = self.ptr as *mut libc::c_void;
+            unsafe {
+                ffi::qaeMemFreeNUMA(&mut p);
+            }
+            self.ptr = ptr::null_mut();
+        }
+    }
+}
+
+pub unsafe extern "C" fn virt_to_phys(virt: *mut libc::c_void) -> ffi::CpaPhysicalAddr {
+    unsafe { ffi::qaeVirtToPhysNUMA(virt) }
+}

--- a/lib/vey-qat/src/openssl_ffi.rs
+++ b/lib/vey-qat/src/openssl_ffi.rs
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use libc::c_int;
+use openssl_sys::{BIGNUM, EVP_MD, RSA};
+
+unsafe extern "C" {
+    pub(crate) fn RSA_padding_add_PKCS1_type_1(
+        to: *mut u8,
+        tlen: c_int,
+        from: *const u8,
+        flen: c_int,
+    ) -> c_int;
+
+    pub(crate) fn RSA_padding_check_none(
+        to: *mut u8,
+        tlen: c_int,
+        from: *const u8,
+        flen: c_int,
+        num: c_int,
+    ) -> c_int;
+
+    pub(crate) fn RSA_padding_add_PKCS1_PSS_mgf1(
+        rsa: *mut RSA,
+        em: *mut u8,
+        m_hash: *const u8,
+        hash: *const EVP_MD,
+        mgf1_hash: *const EVP_MD,
+        salt_len: c_int,
+    ) -> c_int;
+
+    pub(crate) fn BN_priv_rand_range(rnd: *mut BIGNUM, range: *const BIGNUM) -> c_int;
+    pub(crate) fn BN_is_zero(a: *const BIGNUM) -> c_int;
+}

--- a/lib/vey-qat/src/padding.rs
+++ b/lib/vey-qat/src/padding.rs
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use libc::c_int;
+use openssl::foreign_types::ForeignTypeRef;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::Private;
+use openssl::rsa::{Padding, RsaRef};
+use openssl_sys::RSA_padding_check_PKCS1_type_2;
+
+use crate::openssl_ffi;
+
+pub fn add_pkcs1_sign_padding(nid: Nid, digest: &[u8], em: &mut [u8]) -> bool {
+    let tlen = em.len() as c_int;
+    let rc = if nid == Nid::MD5_SHA1 {
+        if digest.len() != 36 {
+            return false;
+        }
+        unsafe {
+            openssl_ffi::RSA_padding_add_PKCS1_type_1(
+                em.as_mut_ptr(),
+                tlen,
+                digest.as_ptr(),
+                digest.len() as c_int,
+            )
+        }
+    } else {
+        let Some(prefix) = digestinfo_prefix(nid) else {
+            return false;
+        };
+        let mut encoded = [0u8; 96];
+        let encoded_len = prefix.len() + digest.len();
+        if encoded_len > encoded.len() {
+            return false;
+        }
+        encoded[..prefix.len()].copy_from_slice(prefix);
+        encoded[prefix.len()..encoded_len].copy_from_slice(digest);
+        unsafe {
+            openssl_ffi::RSA_padding_add_PKCS1_type_1(
+                em.as_mut_ptr(),
+                tlen,
+                encoded.as_ptr(),
+                encoded_len as c_int,
+            )
+        }
+    };
+    rc == 1
+}
+
+pub fn add_pss_sign_padding(rsa: &RsaRef<Private>, nid: Nid, digest: &[u8], em: &mut [u8]) -> bool {
+    let Some(md) = MessageDigest::from_nid(nid) else {
+        return false;
+    };
+    let rc = unsafe {
+        openssl_ffi::RSA_padding_add_PKCS1_PSS_mgf1(
+            rsa.as_ptr(),
+            em.as_mut_ptr(),
+            digest.as_ptr(),
+            md.as_ptr(),
+            md.as_ptr(),
+            -1,
+        )
+    };
+    rc == 1
+}
+
+pub fn check_decrypt_padding(
+    padding: Padding,
+    from: &[u8],
+    to: &mut [u8],
+    rsa_len: usize,
+) -> Option<usize> {
+    let flen = from.len() as c_int;
+    let tlen = to.len() as c_int;
+    let num = rsa_len as c_int;
+    let len = match padding {
+        Padding::NONE => unsafe {
+            openssl_ffi::RSA_padding_check_none(to.as_mut_ptr(), tlen, from.as_ptr(), flen, num)
+        },
+        Padding::PKCS1 => unsafe {
+            RSA_padding_check_PKCS1_type_2(to.as_mut_ptr(), tlen, from.as_ptr(), flen, num)
+        },
+        _ => return None,
+    };
+    if len < 0 { None } else { Some(len as usize) }
+}
+
+fn digestinfo_prefix(nid: Nid) -> Option<&'static [u8]> {
+    match nid {
+        Nid::SHA1 => Some(&[
+            0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04,
+            0x14,
+        ]),
+        Nid::SHA224 => Some(&[
+            0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02,
+            0x04, 0x05, 0x00, 0x04, 0x1c,
+        ]),
+        Nid::SHA256 => Some(&[
+            0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02,
+            0x01, 0x05, 0x00, 0x04, 0x20,
+        ]),
+        Nid::SHA384 => Some(&[
+            0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02,
+            0x02, 0x05, 0x00, 0x04, 0x30,
+        ]),
+        Nid::SHA512 => Some(&[
+            0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02,
+            0x03, 0x05, 0x00, 0x04, 0x40,
+        ]),
+        _ => None,
+    }
+}

--- a/lib/vey-qat/src/rsa.rs
+++ b/lib/vey-qat/src/rsa.rs
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use std::sync::Arc;
+
+use openssl::nid::Nid;
+use openssl::pkey::{PKeyRef, Private};
+use openssl::rsa::Padding;
+use tokio::sync::oneshot;
+
+use crate::Error;
+use crate::ffi::{
+    self, CPA_CY_RSA_PRIVATE_KEY_REP_TYPE_2, CPA_CY_RSA_VERSION_TWO_PRIME, CPA_STATUS_SUCCESS,
+    CpaCyRsaDecryptOpData, CpaCyRsaPrivateKey, CpaFlatBuffer, CpaStatus,
+};
+use crate::mem::DmaBuf;
+use crate::padding::{add_pkcs1_sign_padding, add_pss_sign_padding, check_decrypt_padding};
+use crate::runtime::QatRuntime;
+
+struct RsaPending {
+    tx: Option<oneshot::Sender<Result<Vec<u8>, Error>>>,
+    _p: DmaBuf,
+    _q: DmaBuf,
+    _dp: DmaBuf,
+    _dq: DmaBuf,
+    _qinv: DmaBuf,
+    _input: DmaBuf,
+    output: DmaBuf,
+    key: Box<CpaCyRsaPrivateKey>,
+    op_data: Box<CpaCyRsaDecryptOpData>,
+    out_flat: Box<CpaFlatBuffer>,
+}
+
+unsafe extern "C" fn rsa_cb(
+    tag: *mut libc::c_void,
+    status: CpaStatus,
+    _op: *mut libc::c_void,
+    _out: *mut CpaFlatBuffer,
+) {
+    let pending = unsafe { Box::from_raw(tag as *mut RsaPending) };
+    let result = if status == CPA_STATUS_SUCCESS {
+        Ok(pending.output.as_slice().to_vec())
+    } else {
+        Err(Error::Cpa(status))
+    };
+    if let Some(tx) = pending.tx {
+        let _ = tx.send(result);
+    }
+}
+
+fn bn_to_dma(bn: &openssl::bn::BigNumRef, len: usize) -> Option<DmaBuf> {
+    let mut buf = DmaBuf::alloc(len)?;
+    if !buf.copy_from_be_padded(&bn.to_vec()) {
+        return None;
+    }
+    Some(buf)
+}
+
+fn build_pending(rsa: &openssl::rsa::RsaRef<Private>, input: &[u8]) -> Option<Box<RsaPending>> {
+    let key_len = rsa.size() as usize;
+    if input.len() != key_len {
+        return None;
+    }
+    let half = key_len.div_ceil(2);
+
+    let mut p = bn_to_dma(rsa.p()?, half)?;
+    let mut q = bn_to_dma(rsa.q()?, half)?;
+    let mut dp = bn_to_dma(rsa.dmp1()?, half)?;
+    let mut dq = bn_to_dma(rsa.dmq1()?, half)?;
+    let mut qinv = bn_to_dma(rsa.iqmp()?, half)?;
+    let mut in_buf = DmaBuf::alloc(key_len)?;
+    in_buf.as_mut_slice().copy_from_slice(input);
+    let mut out_buf = DmaBuf::alloc(key_len)?;
+
+    let mut key = Box::new(unsafe { std::mem::zeroed::<CpaCyRsaPrivateKey>() });
+    key.version = CPA_CY_RSA_VERSION_TWO_PRIME;
+    key.privateKeyRepType = CPA_CY_RSA_PRIVATE_KEY_REP_TYPE_2;
+    key.privateKeyRep2.prime1P = p.flat();
+    key.privateKeyRep2.prime2Q = q.flat();
+    key.privateKeyRep2.exponent1Dp = dp.flat();
+    key.privateKeyRep2.exponent2Dq = dq.flat();
+    key.privateKeyRep2.coefficientQInv = qinv.flat();
+
+    let op_data = Box::new(CpaCyRsaDecryptOpData {
+        pRecipientPrivateKey: key.as_mut() as *mut _,
+        inputData: in_buf.flat(),
+    });
+    let out_flat = Box::new(out_buf.flat());
+
+    Some(Box::new(RsaPending {
+        tx: None,
+        _p: p,
+        _q: q,
+        _dp: dp,
+        _dq: dq,
+        _qinv: qinv,
+        _input: in_buf,
+        output: out_buf,
+        key,
+        op_data,
+        out_flat,
+    }))
+}
+
+async fn rsa_private_crt(
+    runtime: &QatRuntime,
+    rsa: &openssl::rsa::RsaRef<Private>,
+    input: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let mut pending = build_pending(rsa, input).ok_or(Error::Prepare)?;
+    // Refresh pointers after move into Box (DmaBuf ptrs are stable; key/op self-refs are not).
+    pending.key.privateKeyRep2.prime1P = pending._p.flat();
+    pending.key.privateKeyRep2.prime2Q = pending._q.flat();
+    pending.key.privateKeyRep2.exponent1Dp = pending._dp.flat();
+    pending.key.privateKeyRep2.exponent2Dq = pending._dq.flat();
+    pending.key.privateKeyRep2.coefficientQInv = pending._qinv.flat();
+    pending.op_data.pRecipientPrivateKey = pending.key.as_mut();
+    pending.op_data.inputData = pending._input.flat();
+    pending.out_flat = Box::new(pending.output.flat());
+
+    let (tx, rx) = oneshot::channel();
+    pending.tx = Some(tx);
+
+    let tag = Box::into_raw(pending);
+    let sts = unsafe {
+        ffi::cpaCyRsaDecrypt(
+            runtime.instance(),
+            Some(rsa_cb),
+            tag as *mut _,
+            (*tag).op_data.as_ref(),
+            (*tag).out_flat.as_mut(),
+        )
+    };
+    if sts != CPA_STATUS_SUCCESS {
+        let _ = unsafe { Box::from_raw(tag) };
+        return Err(Error::Cpa(sts));
+    }
+    rx.await.map_err(|_| Error::Canceled)?
+}
+
+/// PKCS#1 sign via software padding + QAT RSA private primitive.
+pub async fn rsa_sign_pkcs1(
+    runtime: Arc<QatRuntime>,
+    key: &PKeyRef<Private>,
+    nid: Nid,
+    digest: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let rsa = key.rsa().map_err(|_| Error::Prepare)?;
+    let key_len = rsa.size() as usize;
+    let mut em = vec![0u8; key_len];
+    if !add_pkcs1_sign_padding(nid, digest, &mut em) {
+        return Err(Error::Prepare);
+    }
+    rsa_private_crt(&runtime, &rsa, &em).await
+}
+
+pub async fn rsa_sign_pss(
+    runtime: Arc<QatRuntime>,
+    key: &PKeyRef<Private>,
+    nid: Nid,
+    digest: &[u8],
+) -> Result<Vec<u8>, Error> {
+    let rsa = key.rsa().map_err(|_| Error::Prepare)?;
+    let key_len = rsa.size() as usize;
+    let mut em = vec![0u8; key_len];
+    if !add_pss_sign_padding(&rsa, nid, digest, &mut em) {
+        return Err(Error::Prepare);
+    }
+    rsa_private_crt(&runtime, &rsa, &em).await
+}
+
+/// RSA private decrypt + software unpad.
+pub async fn rsa_decrypt(
+    runtime: Arc<QatRuntime>,
+    key: &PKeyRef<Private>,
+    ciphertext: &[u8],
+    padding: Padding,
+) -> Result<Vec<u8>, Error> {
+    let rsa = key.rsa().map_err(|_| Error::Prepare)?;
+    let key_len = rsa.size() as usize;
+    let out = rsa_private_crt(&runtime, &rsa, ciphertext).await?;
+    let mut plain = vec![0u8; key_len];
+    let len = check_decrypt_padding(padding, &out, &mut plain, key_len).ok_or(Error::Prepare)?;
+    plain.truncate(len);
+    Ok(plain)
+}

--- a/lib/vey-qat/src/runtime.rs
+++ b/lib/vey-qat/src/runtime.rs
@@ -1,0 +1,198 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use std::ffi::CString;
+use std::os::fd::RawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+
+use crate::ffi::{
+    self, CPA_ACC_SVC_TYPE_CRYPTO, CPA_INST_RX_NOTIFY_BY_EVENT, CPA_STATUS_RETRY,
+    CPA_STATUS_SUCCESS, CpaInstanceHandle, CpaStatus,
+};
+use crate::mem::virt_to_phys;
+
+static USER_STARTED: OnceLock<CpaStatus> = OnceLock::new();
+
+/// One QAT cryptographic instance with a poll task on a tokio runtime.
+pub struct QatRuntime {
+    instance: CpaInstanceHandle,
+    stop: Arc<AtomicBool>,
+    poll_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+unsafe impl Send for QatRuntime {}
+unsafe impl Sync for QatRuntime {}
+
+impl QatRuntime {
+    /// Start `icp_sal_userStart` (once per process), claim `instance_id`, and
+    /// spawn an epoll-driven poll loop on `handle`.
+    ///
+    /// Requires event notification (`CPA_INST_RX_NOTIFY_BY_EVENT` /
+    /// `CyXIsPolled = 2`) and a valid `icp_sal_CyGetFileDescriptor`.
+    ///
+    /// Returns `None` when qatlib / device init fails or no event FD is
+    /// available (caller should fall back).
+    /// `instance_id` is the index into `cpaCyGetInstances` (0-based).
+    pub fn try_new(process_name: &str, instance_id: u16, handle: &Handle) -> Option<Arc<Self>> {
+        let cname = CString::new(process_name).ok()?;
+        let start_sts =
+            *USER_STARTED.get_or_init(|| unsafe { ffi::icp_sal_userStart(cname.as_ptr()) });
+        if start_sts != CPA_STATUS_SUCCESS {
+            log::warn!("icp_sal_userStart({process_name:?}) failed: {start_sts}");
+            return None;
+        }
+
+        let mut num: u16 = 0;
+        let sts = unsafe { ffi::cpaCyGetNumInstances(&mut num) };
+        if sts != CPA_STATUS_SUCCESS || num == 0 {
+            log::warn!("cpaCyGetNumInstances failed or zero instances (sts={sts}, n={num})");
+            return None;
+        }
+        if instance_id >= num {
+            log::warn!("qat instance_id {instance_id} out of range (available instances: {num})");
+            return None;
+        }
+
+        let mut instances = vec![std::ptr::null_mut(); num as usize];
+        let sts = unsafe { ffi::cpaCyGetInstances(num, instances.as_mut_ptr()) };
+        if sts != CPA_STATUS_SUCCESS {
+            log::warn!("cpaCyGetInstances failed: {sts}");
+            return None;
+        }
+        let instance = instances[instance_id as usize];
+        if instance.is_null() {
+            log::warn!("qat instance_id {instance_id} handle is null");
+            return None;
+        }
+
+        let sts = unsafe { ffi::cpaCySetAddressTranslation(instance, Some(virt_to_phys)) };
+        if sts != CPA_STATUS_SUCCESS {
+            log::warn!("cpaCySetAddressTranslation failed: {sts}");
+            return None;
+        }
+
+        let sts = unsafe { ffi::cpaCyStartInstance(instance) };
+        if sts != CPA_STATUS_SUCCESS {
+            log::warn!("cpaCyStartInstance failed: {sts}");
+            return None;
+        }
+
+        let Some(fd) = try_enable_event_fd(instance, instance_id) else {
+            unsafe {
+                let _ = ffi::cpaCyStopInstance(instance);
+            }
+            return None;
+        };
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_poll = Arc::clone(&stop);
+        // Opaque handle is stable for the lifetime of this runtime.
+        let instance_addr = instance as usize;
+        let poll_task = handle.spawn(async move {
+            poll_loop_epoll(instance_addr, fd, stop_poll).await;
+        });
+
+        Some(Arc::new(QatRuntime {
+            instance,
+            stop,
+            poll_task: Mutex::new(Some(poll_task)),
+        }))
+    }
+
+    pub(crate) fn instance(&self) -> CpaInstanceHandle {
+        self.instance
+    }
+}
+
+impl Drop for QatRuntime {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Ok(mut guard) = self.poll_task.lock()
+            && let Some(task) = guard.take()
+        {
+            task.abort();
+        }
+        unsafe {
+            let _ = ffi::icp_sal_CyPutFileDescriptor(self.instance);
+            let _ = ffi::cpaCyStopInstance(self.instance);
+        }
+    }
+}
+
+/// Request event notification and obtain a pollable FD.
+fn try_enable_event_fd(instance: CpaInstanceHandle, instance_id: u16) -> Option<RawFd> {
+    let sts = unsafe {
+        ffi::cpaInstanceSetResponseMode(
+            instance,
+            CPA_ACC_SVC_TYPE_CRYPTO,
+            CPA_INST_RX_NOTIFY_BY_EVENT,
+        )
+    };
+    if sts != CPA_STATUS_SUCCESS {
+        log::warn!(
+            "qat instance {instance_id}: cpaInstanceSetResponseMode(EVENT) failed: {sts}"
+        );
+        return None;
+    }
+
+    let mut fd: libc::c_int = -1;
+    let sts = unsafe { ffi::icp_sal_CyGetFileDescriptor(instance, &mut fd) };
+    if sts != CPA_STATUS_SUCCESS || fd < 0 {
+        log::warn!(
+            "qat instance {instance_id}: icp_sal_CyGetFileDescriptor failed (sts={sts}, fd={fd})"
+        );
+        return None;
+    }
+
+    // Match QAT Engine: non-blocking FD for epoll readiness.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags >= 0 {
+        let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    }
+
+    log::info!("qat instance {instance_id}: epoll poll via FD {fd}");
+    Some(fd)
+}
+
+async fn poll_loop_epoll(instance_addr: usize, fd: RawFd, stop: Arc<AtomicBool>) {
+    let async_fd = match AsyncFd::with_interest(fd, Interest::READABLE) {
+        Ok(f) => f,
+        Err(e) => {
+            // Validated in `try_new`; should not happen.
+            log::error!("qat AsyncFd::with_interest({fd}) failed: {e}");
+            return;
+        }
+    };
+
+    while !stop.load(Ordering::Relaxed) {
+        let mut guard = match async_fd.readable().await {
+            Ok(g) => g,
+            Err(e) => {
+                log::warn!("qat event FD readable wait failed: {e}");
+                break;
+            }
+        };
+
+        // Drain completions until the instance reports empty.
+        loop {
+            let sts =
+                unsafe { ffi::icp_sal_CyPollInstance(instance_addr as CpaInstanceHandle, 0) };
+            if sts == CPA_STATUS_RETRY {
+                break;
+            }
+            if sts != CPA_STATUS_SUCCESS {
+                log::debug!("icp_sal_CyPollInstance status {sts}");
+                break;
+            }
+        }
+        guard.clear_ready();
+    }
+}

--- a/scripts/coverage/vey-keyless.sh
+++ b/scripts/coverage/vey-keyless.sh
@@ -14,6 +14,9 @@ FEATURES="mimalloc,openssl-async-job"
 if [ "$(uname -m)" = "x86_64" ] && pkg-config --exists crypto-mb; then
 	FEATURES="${FEATURES},crypto-mb"
 fi
+if [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ] && pkg-config --exists qatlib; then
+	FEATURES="${FEATURES},qat"
+fi
 cargo build --features "${FEATURES}" -p vey-keyless -p vey-keyless-ctl -p vey-mkcert -p vey-statsd -p vey-bench
 
 all_binaries=$(find target/debug/ -maxdepth 1 -type f -perm /111 | awk '{print "-object "$0}')

--- a/sphinx/vey-keyless/configuration/backend.rst
+++ b/sphinx/vey-keyless/configuration/backend.rst
@@ -60,6 +60,20 @@ This requires building ``vey-keyless`` with the ``crypto-mb`` feature on
 
 .. versionadded:: 0.6.0
 
+qat
+---
+
+**optional**, **type**: :ref:`qat <conf_backend_driver_qat>`
+
+Enable the Intel ``qatlib`` (QuickAssist) driver.
+
+This requires building ``vey-keyless`` with the ``qat`` feature on Linux
+``x86_64`` and system ``qatlib`` (pkg-config).
+
+**default**: not enabled
+
+.. versionadded:: 0.6.0
+
 Drivers
 =======
 
@@ -114,5 +128,68 @@ the ``crypto-mb`` feature.
 If the CPU lacks a supported ISA for ``crypto_mb`` (for example AVX-512 IFMA
 or AVX2-IFMA), the daemon logs a warning and falls back to OpenSSL for every
 request.
+
+.. versionadded:: 0.6.0
+
+.. _conf_backend_driver_qat:
+
+qat
+---
+
+Use Intel ``qatlib`` asynchronous CPA APIs for RSA-2048/3072/4096 and ECDSA
+(P-256/P-384/P-521). Ed25519 always uses OpenSSL.
+
+This driver does **not** use OpenSSL async jobs or the QAT Engine/Provider.
+Each worker runtime claims its own QAT cryptographic instance and drains
+completions on the same tokio runtime (no dedicated poll OS thread). Instances
+must support event notification (``CPA_INST_RX_NOTIFY_BY_EVENT`` /
+``CyXIsPolled = 2``); the worker waits on ``icp_sal_CyGetFileDescriptor`` via
+tokio ``AsyncFd``. Missing event FDs cause init failure. PKCS#1 / PSS padding
+is applied in software; QAT performs the RSA private primitive. On init
+failure, timeout, or operation error the request falls back to synchronous
+OpenSSL.
+
+This driver requires worker runtimes and a multiplex-enabled ``cloudflare``
+server so requests are dispatched to backend workers.
+
+The following keys are supported for this driver:
+
+- process_name
+
+  **optional**, **type**: string
+
+  Process name passed to ``icp_sal_userStart``, matching the QAT service
+  configuration.
+
+  **default**: ``SSL``
+
+- op_timeout
+
+  **optional**, **type**: :external+values:ref:`humanize duration <conf_value_humanize_duration>`
+
+  Timeout waiting for a single QAT operation to complete.
+
+  **default**: 1s
+
+Each worker ``N`` (0-based) must have environment variable
+``WORKER_<N>_QAT_INSTANCE`` set to a zero-based index into
+``cpaCyGetInstances``. Missing, invalid, or out-of-range values cause init
+failure and OpenSSL fallback for that worker.
+
+Example::
+
+   WORKER_0_QAT_INSTANCE=0
+   WORKER_1_QAT_INSTANCE=1
+
+String form ``backend: qat`` / ``backend: qatlib`` uses the defaults above.
+Map form example::
+
+   backend:
+     qat:
+       process_name: SSL
+       op_timeout: 1s
+
+This driver is only available on Linux ``x86_64`` when ``vey-keyless`` is
+built with the ``qat`` feature.
 
 .. versionadded:: 0.6.0

--- a/vey-keyless/Cargo.toml
+++ b/vey-keyless/Cargo.toml
@@ -22,7 +22,7 @@ capnp-rpc.workspace = true
 openssl.workspace = true
 openssl-probe = { workspace = true, optional = true }
 tokio-rustls.workspace = true
-tokio = { workspace = true, features = ["time", "sync", "fs"] }
+tokio = { workspace = true, features = ["time", "sync", "fs", "rt"] }
 yaml-rust.workspace = true
 jiff.workspace = true
 uuid.workspace = true
@@ -55,6 +55,9 @@ vey-keyless-proto = { path = "proto" }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 vey-crypto-mb = { workspace = true, optional = true }
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+vey-qat = { workspace = true, optional = true }
+
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 inotify = "0.11"
 
@@ -79,3 +82,4 @@ vendored-aws-lc = ["openssl/aws-lc", "openssl-probe"]
 vendored-aws-lc-fips = ["openssl/aws-lc-fips", "openssl-probe"]
 openssl-async-job = ["vey-openssl/async-job", "vey-daemon/openssl-async-job"]
 crypto-mb = ["dep:vey-crypto-mb"]
+qat = ["dep:vey-qat"]

--- a/vey-keyless/src/backend/mod.rs
+++ b/vey-keyless/src/backend/mod.rs
@@ -22,6 +22,9 @@ pub(crate) use async_job::OpensslOperation;
 #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
 mod crypto_mb;
 
+#[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+mod qat;
+
 mod simple;
 
 pub(crate) struct DispatchedKeylessRequest {
@@ -40,39 +43,56 @@ trait Backend {
     async fn run_ed25519(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>);
 }
 
-pub fn create(_id: usize, handle: &Handle) -> anyhow::Result<()> {
+pub fn create(id: usize, handle: &Handle) -> anyhow::Result<()> {
     let config = crate::config::backend::get_config();
+    let channel_size = config.dispatch_channel_size;
+    let counter_shift = config.dispatch_counter_shift;
 
-    macro_rules! setup {
-        ($run:ident, $register:ident) => {
-            let (sender, receiver) = mpsc::channel(config.dispatch_channel_size);
-            match &config.driver {
-                BackendDriverConfig::Simple => {
-                    let backend = simple::SimpleBackend::new();
-                    handle.spawn(backend.$run(receiver));
-                }
-                #[cfg(feature = "openssl-async-job")]
-                BackendDriverConfig::AsyncJob(driver) => {
-                    let backend = async_job::AsyncJobBackend::new(*driver);
-                    handle.spawn(backend.$run(receiver));
-                }
-                #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
-                BackendDriverConfig::CryptoMb(driver) => {
-                    let backend = crypto_mb::CryptoMbBackend::new(*driver);
-                    handle.spawn(backend.$run(receiver));
-                }
+    macro_rules! spawn_all {
+        ($new_backend:expr) => {{
+            macro_rules! setup {
+                ($run:ident, $register:ident) => {{
+                    let (sender, receiver) = mpsc::channel(channel_size);
+                    handle.spawn(($new_backend).$run(receiver));
+                    dispatch::$register(sender, counter_shift);
+                }};
             }
-            dispatch::$register(sender, config.dispatch_counter_shift);
-        };
+            setup!(run_rsa_2048, register_rsa_2048);
+            setup!(run_rsa_3072, register_rsa_3072);
+            setup!(run_rsa_4096, register_rsa_4096);
+            setup!(run_ecdsa_p256, register_ecdsa_p256);
+            setup!(run_ecdsa_p384, register_ecdsa_p384);
+            setup!(run_ecdsa_p521, register_ecdsa_p521);
+            setup!(run_ed25519, register_ed25519);
+        }};
     }
 
-    setup!(run_rsa_2048, register_rsa_2048);
-    setup!(run_rsa_3072, register_rsa_3072);
-    setup!(run_rsa_4096, register_rsa_4096);
-    setup!(run_ecdsa_p256, register_ecdsa_p256);
-    setup!(run_ecdsa_p384, register_ecdsa_p384);
-    setup!(run_ecdsa_p521, register_ecdsa_p521);
-    setup!(run_ed25519, register_ed25519);
+    match &config.driver {
+        BackendDriverConfig::Simple => {
+            log::debug!("starting simple backend on worker {id}");
+            spawn_all!(simple::SimpleBackend::new());
+        }
+        #[cfg(feature = "openssl-async-job")]
+        BackendDriverConfig::AsyncJob(driver) => {
+            log::debug!("starting openssl async-job backend on worker {id}");
+            let driver = *driver;
+            spawn_all!(async_job::AsyncJobBackend::new(driver));
+        }
+        #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
+        BackendDriverConfig::CryptoMb(driver) => {
+            log::debug!("starting crypto-mb backend on worker {id}");
+            let driver = *driver;
+            spawn_all!(crypto_mb::CryptoMbBackend::new(driver));
+        }
+        #[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+        BackendDriverConfig::Qat(driver) => {
+            log::debug!("starting qat backend on worker {id}");
+            // One QAT instance + poll task per worker; shared by all algo queues.
+            let runtime = qat::QatBackend::create_runtime(driver, id, handle);
+            let op_timeout = driver.op_timeout;
+            spawn_all!(qat::QatBackend::new(runtime.clone(), op_timeout));
+        }
+    }
 
     Ok(())
 }

--- a/vey-keyless/src/backend/qat/mod.rs
+++ b/vey-keyless/src/backend/qat/mod.rs
@@ -1,0 +1,162 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+
+use vey_qat::{QatRuntime, ecdsa_sign_der, rsa_decrypt, rsa_sign_pkcs1, rsa_sign_pss};
+
+use super::{Backend, DispatchedKeylessRequest};
+use crate::config::backend::QatBackendConfig;
+use crate::protocol::{KeylessAction, KeylessDataResponse, KeylessResponse};
+
+pub(super) struct QatBackend {
+    runtime: Option<Arc<QatRuntime>>,
+    op_timeout: Duration,
+}
+
+impl QatBackend {
+    /// Build a backend for one worker.
+    ///
+    /// Instance index comes from env `WORKER_<N>_QAT_INSTANCE` where `N` is
+    /// `worker_id` (0-based), mapping into `cpaCyGetInstances`.
+    pub(super) fn create_runtime(
+        config: &QatBackendConfig,
+        worker_id: usize,
+        handle: &Handle,
+    ) -> Option<Arc<QatRuntime>> {
+        let instance_id = match instance_id_from_env(worker_id) {
+            Ok(id) => id,
+            Err(e) => {
+                log::warn!(
+                    "qat backend init failed for worker {worker_id}: {e}; using OpenSSL for this worker"
+                );
+                return None;
+            }
+        };
+        let runtime = QatRuntime::try_new(&config.process_name, instance_id, handle);
+        if runtime.is_none() {
+            log::warn!(
+                "qat backend init failed (process_name={:?}, instance_id={instance_id}, worker={worker_id}); using OpenSSL for this worker",
+                config.process_name,
+            );
+        }
+        runtime
+    }
+
+    pub(super) fn new(runtime: Option<Arc<QatRuntime>>, op_timeout: Duration) -> Self {
+        QatBackend {
+            runtime,
+            op_timeout,
+        }
+    }
+
+    async fn process_openssl(req: DispatchedKeylessRequest) {
+        let rsp = req.inner.process_by_openssl(&req.key);
+        let _ = req.rsp_sender.send(req.inner.build_response(rsp)).await;
+    }
+
+    async fn loop_run(self, mut receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        while let Some(req) = receiver.recv().await {
+            let Some(runtime) = self.runtime.clone() else {
+                Self::process_openssl(req).await;
+                continue;
+            };
+
+            let DispatchedKeylessRequest {
+                inner,
+                key,
+                rsp_sender,
+            } = req;
+            let msg_id = inner.inner.id;
+            let action = inner.inner.action;
+            let payload = inner.inner.payload.clone();
+            let stats = inner.stats.clone();
+            let timeout = self.op_timeout;
+
+            tokio::spawn(async move {
+                let qat = tokio::time::timeout(timeout, async {
+                    match action {
+                        KeylessAction::RsaDecrypt(padding) => {
+                            rsa_decrypt(runtime, &key, &payload, padding)
+                                .await
+                                .map(|plain| KeylessDataResponse::with_payload(msg_id, plain))
+                        }
+                        KeylessAction::RsaSign(nid) => rsa_sign_pkcs1(runtime, &key, nid, &payload)
+                            .await
+                            .map(|sig| KeylessDataResponse::with_payload(msg_id, sig)),
+                        KeylessAction::RsaPssSign(nid) => {
+                            rsa_sign_pss(runtime, &key, nid, &payload)
+                                .await
+                                .map(|sig| KeylessDataResponse::with_payload(msg_id, sig))
+                        }
+                        KeylessAction::EcdsaSign(_) => ecdsa_sign_der(runtime, &key, &payload)
+                            .await
+                            .map(|der| KeylessDataResponse::with_payload(msg_id, der)),
+                        _ => Err(vey_qat::Error::Prepare),
+                    }
+                })
+                .await;
+
+                let rsp = match qat {
+                    Ok(Ok(data)) => {
+                        stats.add_passed();
+                        KeylessResponse::Data(data)
+                    }
+                    Ok(Err(_)) | Err(_) => {
+                        // Timeout or QAT failure: synchronous OpenSSL fallback.
+                        inner.process_by_openssl(&key)
+                    }
+                };
+                let _ = rsp_sender.send(inner.build_response(rsp)).await;
+            });
+        }
+    }
+}
+
+fn instance_id_from_env(worker_id: usize) -> anyhow::Result<u16> {
+    let key = format!("WORKER_{worker_id}_QAT_INSTANCE");
+    let value = std::env::var(&key)
+        .map_err(|_| anyhow::anyhow!("env {key} is not set"))?;
+    value
+        .parse::<u16>()
+        .map_err(|e| anyhow::anyhow!("env {key}={value:?} is not a valid u16: {e}"))
+}
+
+impl Backend for QatBackend {
+    async fn run_rsa_2048(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        self.loop_run(receiver).await
+    }
+
+    async fn run_rsa_3072(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        self.loop_run(receiver).await
+    }
+
+    async fn run_rsa_4096(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        self.loop_run(receiver).await
+    }
+
+    async fn run_ecdsa_p256(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        self.loop_run(receiver).await
+    }
+
+    async fn run_ecdsa_p384(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        self.loop_run(receiver).await
+    }
+
+    async fn run_ecdsa_p521(self, receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        self.loop_run(receiver).await
+    }
+
+    async fn run_ed25519(self, mut receiver: mpsc::Receiver<DispatchedKeylessRequest>) {
+        // qatlib has no EdDSA sign; always OpenSSL.
+        while let Some(req) = receiver.recv().await {
+            Self::process_openssl(req).await;
+        }
+    }
+}

--- a/vey-keyless/src/config/backend/mod.rs
+++ b/vey-keyless/src/config/backend/mod.rs
@@ -19,6 +19,11 @@ mod crypto_mb;
 #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
 pub(crate) use crypto_mb::CryptoMbBackendConfig;
 
+#[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+mod qat;
+#[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+pub(crate) use qat::QatBackendConfig;
+
 static BACKEND_CONFIG: OnceLock<BackendConfig> = OnceLock::new();
 
 pub(crate) struct BackendConfig {
@@ -49,6 +54,8 @@ pub(crate) enum BackendDriverConfig {
     AsyncJob(AsyncJobBackendConfig),
     #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
     CryptoMb(CryptoMbBackendConfig),
+    #[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+    Qat(QatBackendConfig),
 }
 
 pub(super) fn load(value: &Yaml) -> anyhow::Result<()> {
@@ -76,6 +83,12 @@ pub(super) fn load(value: &Yaml) -> anyhow::Result<()> {
                     config.driver = BackendDriverConfig::CryptoMb(driver);
                     Ok(())
                 }
+                #[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+                "qat" | "qatlib" => {
+                    let driver = QatBackendConfig::parse_yaml(v)?;
+                    config.driver = BackendDriverConfig::Qat(driver);
+                    Ok(())
+                }
                 _ => Err(anyhow!("invalid key {k}")),
             })?;
         }
@@ -88,6 +101,10 @@ pub(super) fn load(value: &Yaml) -> anyhow::Result<()> {
             #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
             "crypto_mb" | "cryptomb" => {
                 config.driver = BackendDriverConfig::CryptoMb(CryptoMbBackendConfig::default());
+            }
+            #[cfg(all(feature = "qat", target_os = "linux", target_arch = "x86_64"))]
+            "qat" | "qatlib" => {
+                config.driver = BackendDriverConfig::Qat(QatBackendConfig::default());
             }
             _ => return Err(anyhow!("unsupported backend type {s}")),
         },

--- a/vey-keyless/src/config/backend/qat.rs
+++ b/vey-keyless/src/config/backend/qat.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: 2026 VEY-OSS Developers.
+ */
+
+use std::time::Duration;
+
+use anyhow::anyhow;
+use yaml_rust::Yaml;
+
+#[derive(Debug, Clone)]
+pub(crate) struct QatBackendConfig {
+    pub(crate) process_name: String,
+    pub(crate) op_timeout: Duration,
+}
+
+impl Default for QatBackendConfig {
+    fn default() -> Self {
+        QatBackendConfig {
+            process_name: "SSL".to_string(),
+            op_timeout: Duration::from_secs(1),
+        }
+    }
+}
+
+impl QatBackendConfig {
+    pub(super) fn parse_yaml(value: &Yaml) -> anyhow::Result<Self> {
+        match value {
+            Yaml::Hash(map) => {
+                let mut config = QatBackendConfig::default();
+                vey_yaml::foreach_kv(map, |k, v| match vey_yaml::key::normalize(k).as_str() {
+                    "process_name" => {
+                        config.process_name = vey_yaml::value::as_string(v)?;
+                        Ok(())
+                    }
+                    "op_timeout" => {
+                        config.op_timeout = vey_yaml::humanize::as_duration(v)?;
+                        Ok(())
+                    }
+                    _ => Err(anyhow!("invalid key {k}")),
+                })?;
+                Ok(config)
+            }
+            Yaml::Null | Yaml::Boolean(true) => Ok(QatBackendConfig::default()),
+            _ => Err(anyhow!("yaml value type for `qat` backend should be `map`")),
+        }
+    }
+}

--- a/vey-keyless/src/protocol/response/mod.rs
+++ b/vey-keyless/src/protocol/response/mod.rs
@@ -35,7 +35,10 @@ impl KeylessDataResponse {
         }
     }
 
-    #[cfg(all(feature = "crypto-mb", target_arch = "x86_64"))]
+    #[cfg(any(
+        all(feature = "crypto-mb", target_arch = "x86_64"),
+        all(feature = "qat", target_os = "linux", target_arch = "x86_64"),
+    ))]
     pub(crate) fn with_payload(id: u32, payload: impl Into<Vec<u8>>) -> Self {
         KeylessDataResponse {
             id,


### PR DESCRIPTION
Introduce vey-qat for CPA RSA/ECDSA offload with a poll thread, and wire a configurable backend: qat driver (process_name, instance_id, op_timeout) with OpenSSL fallback.