### PR TITLE
fix(fluentd): parse retry queue length from yaml

### DIFF
--- a/lib/vey-fluentd/src/config/yaml.rs
+++ b/lib/vey-fluentd/src/config/yaml.rs
@@ -96,6 +96,12 @@ impl FluentdClientConfig {
                         config.set_flush_interval(interval);
                         Ok(())
                     }
+                    "retry_queue_len" => {
+                        let len = vey_yaml::value::as_usize(v)
+                            .context(format!("invalid usize value for key {k}"))?;
+                        config.set_retry_queue_len(len);
+                        Ok(())
+                    }
                     _ => Err(anyhow!("invalid key {k}")),
                 })?;
 
@@ -143,6 +149,7 @@ mod tests {
                 connect_delay: "1s"
                 write_timeout: "500ms"
                 flush_interval: "100ms"
+                retry_queue_len: 64
             "#
         );
         let config = FluentdClientConfig::parse_yaml(&yaml, None).unwrap();
@@ -170,6 +177,7 @@ mod tests {
         assert_eq!(config.connect_delay, std::time::Duration::from_secs(1));
         assert_eq!(config.write_timeout, std::time::Duration::from_millis(500));
         assert_eq!(config.flush_interval, std::time::Duration::from_millis(100));
+        assert_eq!(config.retry_queue_len, 64);
 
         let yaml = yaml_doc!(
             r#"


### PR DESCRIPTION
## Summary
- parse the Fluentd retry_queue_len YAML option
- cover the parsed value in the existing configuration test

This mirrors the G3-side support requested during review of bytedance/g3#1119.

## Validation
- cargo fmt --all --check
- cargo test -p vey-fluentd --features yaml (cannot reach project tests in my Windows environment because OpenSSL development libraries are unavailable)